### PR TITLE
Use net.JoinHostPort instead of string concat

### DIFF
--- a/transport/udp-transport.go
+++ b/transport/udp-transport.go
@@ -24,7 +24,7 @@ type UDPTransport struct {
 func NewUDPTransport(scheme string, host string, port int) (*UDPTransport, error) {
 	t := new(UDPTransport)
 	var err error
-	t.conn, err = net.Dial(scheme, host+":"+strconv.Itoa(port))
+	t.conn, err = net.Dial(scheme, net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return nil, err
 	}

--- a/transport/websocket-transport.go
+++ b/transport/websocket-transport.go
@@ -36,9 +36,9 @@ func NewWebSocketTransport(protocol string, wsUri string) (*WebSocketTransport, 
 		}
 
 		if protocol == "wss-ipv4" {
-			return net.Dial("tcp4", u.Host+":"+strconv.Itoa(u.Port))
+			return net.Dial("tcp4", net.JoinHostPort(u.Host, strconv.Itoa(u.Port)))
 		} else {
-			return net.Dial("tcp6", u.Host+":"+strconv.Itoa(u.Port))
+			return net.Dial("tcp6", net.JoinHostPort(u.Host, strconv.Itoa(u.Port)))
 		}
 	}
 


### PR DESCRIPTION
Constructing host:port using string concatenation breaks if the URI contains a literal IPv6 address.

For example, when we query "udp6" router `[2001:db8::1]:6363`:

```bash
curl -d 'transport=udp6&router=%5B2001%3Adb8%3A%3A1%5D%3A6363&name=%2Fndn%2Fedu%2Fmemphis%2Fping&suffix=1' http://127.0.0.1:3000/probe
```

The concatenated host:port would be `2001:db8::1:6363`, which is not acceptable by `net.Dial`.

This PR changes such usage to [net.JoinHostPort](https://golang.org/pkg/net/#JoinHostPort), which adds square brackets around literal IPv6 address, so that the host:port string is correctly constructed as `[2001:db8::1]:6363`.
